### PR TITLE
Add Go ubtd daemon + ubtctl CLI scaffold (P0–P2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+bin/
+*.sock
+*.log
+
+# Python
+__pycache__/
+*.py[cod]
+.venv/
+venv/
+*.egg-info/

--- a/cli/ubtctl/README.md
+++ b/cli/ubtctl/README.md
@@ -1,15 +1,60 @@
-# ubtctl CLI (placeholder)
+# ubtctl + ubtd
 
-`ubtctl` will become the unified command-line interface for managing Universal
-Bluetooth SDK deployments (pairing devices, pushing configs, triggering sends,
-etc.).
+`ubtctl` is the Universal Bluetooth CLI; `ubtd` is the long-lived control-plane
+daemon that owns every Bluetooth session. The CLI never touches the radio
+directly — it speaks the wire protocol in
+[`common/protocol/framing.md`](../../common/protocol/framing.md) to the daemon.
 
-Proposed features:
+```
+ubtctl ──UDS──> ubtd ──port──> TransportDriver ──> radio
+```
 
-- `ubtctl server start/stop/status`
-- `ubtctl client send --file text.json`
-- `ubtctl discover` to list nearby devices/services
+The same wire surface is what the AI planner targets, so adding a verb here
+extends the AI tool registry automatically.
 
-Implementation can build on the Python SDK initially, with later support for Go
-or Rust binaries.
+## Build
 
+```bash
+go build -o bin/ubtd  ./cli/ubtd
+go build -o bin/ubtctl ./cli/ubtctl
+```
+
+## Quick start
+
+```bash
+# 1. Start the daemon (registers the in-memory stub driver by default).
+./bin/ubtd --socket /tmp/ubtd.sock &
+
+# 2. Talk to it.
+UBTD_SOCKET=/tmp/ubtd.sock ./bin/ubtctl version
+UBTD_SOCKET=/tmp/ubtd.sock ./bin/ubtctl status
+UBTD_SOCKET=/tmp/ubtd.sock ./bin/ubtctl capabilities
+UBTD_SOCKET=/tmp/ubtd.sock ./bin/ubtctl discover --scan-timeout 3
+UBTD_SOCKET=/tmp/ubtd.sock ./bin/ubtctl send --address AA:BB:CC:DD:EE:01 --data 'hi'
+```
+
+## Commands
+
+| Command         | Purpose                                              |
+|-----------------|------------------------------------------------------|
+| `ping`          | Liveness + clock-skew check                          |
+| `version`       | CLI + daemon + protocol versions                     |
+| `status`        | Daemon health and active sessions                    |
+| `capabilities`  | Per-transport feature matrix                         |
+| `discover`      | Stream device scan results until timeout             |
+| `send`          | Push a payload (`--data`, `--file`, or stdin)        |
+
+Run `ubtctl <command> -h` for per-command flags.
+
+## Configuration
+
+| Variable        | Default                                    | Notes                       |
+|-----------------|--------------------------------------------|-----------------------------|
+| `UBTD_SOCKET`   | `$XDG_RUNTIME_DIR/ubtd.sock` or `/tmp/ubtd.sock` | Override with `--socket` |
+| `UBTD_LOG_LEVEL`| `info`                                     | `debug`/`info`/`warn`/`error` |
+
+## Status
+
+Phase 2 of the plan in the repo root README: typed CLI surface working
+end-to-end against the stub driver. Native Bluetooth drivers and the AI
+planner ride on the same wire format and ship next.

--- a/cli/ubtctl/client/client.go
+++ b/cli/ubtctl/client/client.go
@@ -1,0 +1,136 @@
+// Package client wraps a duplex Unix socket connection to ubtd and exposes
+// the request/response semantics defined in common/protocol/framing.md.
+package client
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/sraodev/bluetooth-service-rfcomm-python/sdk/go/pkg/protocol"
+)
+
+type Client struct {
+	conn net.Conn
+	mu   sync.Mutex // serialises writes; reads happen on the caller goroutine
+}
+
+func Dial(socketPath string) (*Client, error) {
+	c, err := net.DialTimeout("unix", socketPath, 2*time.Second)
+	if err != nil {
+		return nil, fmt.Errorf("dial %s: %w", socketPath, err)
+	}
+	return &Client{conn: c}, nil
+}
+
+func (c *Client) Close() error { return c.conn.Close() }
+
+// Call sends a single request and waits for the matching response,
+// dropping events that arrive on the same id (for streaming, use Stream).
+func (c *Client) Call(ctx context.Context, method string, params any) (map[string]any, error) {
+	id, err := c.send(method, params)
+	if err != nil {
+		return nil, err
+	}
+	for {
+		env, err := c.readNext(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if env.ID != id {
+			continue
+		}
+		if env.Kind == protocol.KindEvent {
+			continue
+		}
+		if env.Error != nil {
+			return nil, env.Error
+		}
+		return env.Result, nil
+	}
+}
+
+// Stream sends a request and invokes onEvent for every event sharing the
+// originating id, returning when the terminating response arrives.
+func (c *Client) Stream(ctx context.Context, method string, params any, onEvent func(map[string]any)) error {
+	id, err := c.send(method, params)
+	if err != nil {
+		return err
+	}
+	for {
+		env, err := c.readNext(ctx)
+		if err != nil {
+			return err
+		}
+		if env.ID != id {
+			continue
+		}
+		switch env.Kind {
+		case protocol.KindEvent:
+			onEvent(env.Params)
+		case protocol.KindResponse:
+			if env.Error != nil {
+				return env.Error
+			}
+			return nil
+		}
+	}
+}
+
+func (c *Client) send(method string, params any) (string, error) {
+	id, err := newID()
+	if err != nil {
+		return "", err
+	}
+	env := &protocol.Envelope{
+		ID:     id,
+		Kind:   protocol.KindRequest,
+		Method: method,
+		Params: paramsMap(params),
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if err := protocol.WriteFrame(c.conn, env); err != nil {
+		return "", err
+	}
+	return id, nil
+}
+
+func (c *Client) readNext(ctx context.Context) (*protocol.Envelope, error) {
+	if dl, ok := ctx.Deadline(); ok {
+		_ = c.conn.SetReadDeadline(dl)
+	} else {
+		_ = c.conn.SetReadDeadline(time.Time{})
+	}
+	env, err := protocol.ReadFrame(c.conn)
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		return nil, err
+	}
+	return env, nil
+}
+
+func paramsMap(p any) map[string]any {
+	if p == nil {
+		return nil
+	}
+	if m, ok := p.(map[string]any); ok {
+		return m
+	}
+	// Marshal-then-unmarshal; small structs only.
+	return marshalToMap(p)
+}
+
+func newID() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b[:]), nil
+}

--- a/cli/ubtctl/client/marshal.go
+++ b/cli/ubtctl/client/marshal.go
@@ -1,0 +1,26 @@
+package client
+
+import "encoding/json"
+
+func marshalToMap(v any) map[string]any {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return map[string]any{"_marshal_error": err.Error()}
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		return map[string]any{"_unmarshal_error": err.Error()}
+	}
+	return m
+}
+
+// Decode rehydrates a result map (as returned by Client.Call) into a typed
+// destination. Lets callers stay typed without sprinkling json marshal/unmarshal
+// throughout command handlers.
+func Decode(src map[string]any, dst any) error {
+	b, err := json.Marshal(src)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(b, dst)
+}

--- a/cli/ubtctl/commands/capabilities.go
+++ b/cli/ubtctl/commands/capabilities.go
@@ -1,0 +1,46 @@
+package commands
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/sraodev/bluetooth-service-rfcomm-python/cli/ubtctl/client"
+	"github.com/sraodev/bluetooth-service-rfcomm-python/sdk/go/pkg/protocol"
+)
+
+type capabilitiesCmd struct{}
+
+func (capabilitiesCmd) Name() string     { return "capabilities" }
+func (capabilitiesCmd) Synopsis() string { return "list per-transport capabilities advertised by ubtd" }
+
+func (capabilitiesCmd) Run(args []string, _ RootInfo) error {
+	fs := flag.NewFlagSet("capabilities", flag.ContinueOnError)
+	var b baseFlags
+	bindBase(fs, &b)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	c, ctx, cancel, err := dial(b)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+	defer c.Close()
+
+	res, err := c.Call(ctx, protocol.MethodCapabilities, nil)
+	if err != nil {
+		return err
+	}
+	var r protocol.CapabilitiesResult
+	if err := client.Decode(res, &r); err != nil {
+		return err
+	}
+	fmt.Printf("%-12s %-9s %-5s %-7s %s\n", "TRANSPORT", "DISCOVER", "PAIR", "STREAM", "MTU")
+	for _, c := range r.Capabilities {
+		fmt.Printf("%-12s %-9v %-5v %-7v %d\n", c.Transport, c.Discover, c.Pair, c.Stream, c.MaxMTU)
+	}
+	return nil
+}
+
+func init() { register(capabilitiesCmd{}) }

--- a/cli/ubtctl/commands/common.go
+++ b/cli/ubtctl/commands/common.go
@@ -1,0 +1,29 @@
+package commands
+
+import (
+	"context"
+	"flag"
+	"time"
+
+	"github.com/sraodev/bluetooth-service-rfcomm-python/cli/ubtctl/client"
+	"github.com/sraodev/bluetooth-service-rfcomm-python/sdk/go/pkg/sockaddr"
+)
+
+type baseFlags struct {
+	socket  string
+	timeout time.Duration
+}
+
+func bindBase(fs *flag.FlagSet, b *baseFlags) {
+	fs.StringVar(&b.socket, "socket", sockaddr.Default(), "ubtd socket path")
+	fs.DurationVar(&b.timeout, "timeout", 10*time.Second, "request timeout")
+}
+
+func dial(b baseFlags) (*client.Client, context.Context, context.CancelFunc, error) {
+	c, err := client.Dial(b.socket)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), b.timeout)
+	return c, ctx, cancel, nil
+}

--- a/cli/ubtctl/commands/discover.go
+++ b/cli/ubtctl/commands/discover.go
@@ -1,0 +1,45 @@
+package commands
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/sraodev/bluetooth-service-rfcomm-python/cli/ubtctl/client"
+	"github.com/sraodev/bluetooth-service-rfcomm-python/sdk/go/pkg/protocol"
+)
+
+type discoverCmd struct{}
+
+func (discoverCmd) Name() string     { return "discover" }
+func (discoverCmd) Synopsis() string { return "scan for nearby devices and stream them as they appear" }
+
+func (discoverCmd) Run(args []string, _ RootInfo) error {
+	fs := flag.NewFlagSet("discover", flag.ContinueOnError)
+	var b baseFlags
+	bindBase(fs, &b)
+	transport := fs.String("transport", "", "limit scan to one transport (e.g., rfcomm, ble)")
+	timeout := fs.Int("scan-timeout", 8, "scan duration, seconds")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	c, ctx, cancel, err := dial(b)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+	defer c.Close()
+
+	params := protocol.DiscoverParams{Transport: *transport, TimeoutSeconds: *timeout}
+	fmt.Printf("%-20s %-22s %-8s %s\n", "ADDRESS", "NAME", "RSSI", "TRANSPORT")
+	return c.Stream(ctx, protocol.MethodDiscover, params, func(ev map[string]any) {
+		var d protocol.Device
+		if err := client.Decode(ev, &d); err != nil {
+			fmt.Printf("(decode error: %v)\n", err)
+			return
+		}
+		fmt.Printf("%-20s %-22s %-8d %s\n", d.Address, d.Name, d.RSSI, d.Transport)
+	})
+}
+
+func init() { register(discoverCmd{}) }

--- a/cli/ubtctl/commands/ping.go
+++ b/cli/ubtctl/commands/ping.go
@@ -1,0 +1,48 @@
+package commands
+
+import (
+	"flag"
+	"fmt"
+	"time"
+
+	"github.com/sraodev/bluetooth-service-rfcomm-python/cli/ubtctl/client"
+	"github.com/sraodev/bluetooth-service-rfcomm-python/sdk/go/pkg/protocol"
+)
+
+type pingCmd struct{}
+
+func (pingCmd) Name() string     { return "ping" }
+func (pingCmd) Synopsis() string { return "round-trip a Ping request to ubtd (clock skew + liveness)" }
+
+func (pingCmd) Run(args []string, _ RootInfo) error {
+	fs := flag.NewFlagSet("ping", flag.ContinueOnError)
+	var b baseFlags
+	bindBase(fs, &b)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	c, ctx, cancel, err := dial(b)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+	defer c.Close()
+
+	start := time.Now()
+	res, err := c.Call(ctx, protocol.MethodPing, nil)
+	if err != nil {
+		return err
+	}
+	rtt := time.Since(start)
+
+	var p protocol.PingResult
+	if err := client.Decode(res, &p); err != nil {
+		return err
+	}
+	skew := time.Now().UnixMilli() - p.ServerTimeUnixMs
+	fmt.Printf("%s  rtt=%s  clock-skew=%d ms\n", p.Pong, rtt, skew)
+	return nil
+}
+
+func init() { register(pingCmd{}) }

--- a/cli/ubtctl/commands/registry.go
+++ b/cli/ubtctl/commands/registry.go
@@ -1,0 +1,53 @@
+// Package commands hosts the ubtctl subcommand registry.
+//
+// Each subcommand is a small struct implementing Command. Keeping the
+// registry typed (rather than hand-rolled string switches scattered
+// across main) is what lets the AI planner enumerate the surface and
+// generate tool schemas mechanically.
+package commands
+
+import (
+	"fmt"
+	"sort"
+)
+
+type RootInfo struct {
+	CLIVersion string
+	Commit     string
+}
+
+type Command interface {
+	Name() string
+	Synopsis() string
+	Run(args []string, info RootInfo) error
+}
+
+var registry = map[string]Command{}
+
+func register(c Command) {
+	registry[c.Name()] = c
+}
+
+func Lookup(name string) (Command, bool) {
+	c, ok := registry[name]
+	return c, ok
+}
+
+func PrintRootUsage(version string) {
+	fmt.Printf("ubtctl %s — Universal Bluetooth CLI\n\n", version)
+	fmt.Println("Usage:")
+	fmt.Println("  ubtctl <command> [flags]")
+	fmt.Println()
+	fmt.Println("Commands:")
+	names := make([]string, 0, len(registry))
+	for n := range registry {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	for _, n := range names {
+		fmt.Printf("  %-12s %s\n", n, registry[n].Synopsis())
+	}
+	fmt.Println()
+	fmt.Println("Flags common to all commands:")
+	fmt.Println("  --socket <path>   override ubtd socket path (env UBTD_SOCKET)")
+}

--- a/cli/ubtctl/commands/send.go
+++ b/cli/ubtctl/commands/send.go
@@ -1,0 +1,80 @@
+package commands
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/sraodev/bluetooth-service-rfcomm-python/cli/ubtctl/client"
+	"github.com/sraodev/bluetooth-service-rfcomm-python/sdk/go/pkg/protocol"
+)
+
+type sendCmd struct{}
+
+func (sendCmd) Name() string     { return "send" }
+func (sendCmd) Synopsis() string { return "send a payload to a peer (file, stdin, or --data)" }
+
+func (sendCmd) Run(args []string, _ RootInfo) error {
+	fs := flag.NewFlagSet("send", flag.ContinueOnError)
+	var b baseFlags
+	bindBase(fs, &b)
+	address := fs.String("address", "", "peer address (required)")
+	transport := fs.String("transport", "rfcomm", "transport name")
+	port := fs.Int("port", 0, "RFCOMM channel / GATT handle (0 = driver default)")
+	file := fs.String("file", "", "read payload from file ('-' for stdin)")
+	inline := fs.String("data", "", "inline payload string (mutually exclusive with --file)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *address == "" {
+		return errors.New("--address is required")
+	}
+
+	payload, err := readPayload(*file, *inline)
+	if err != nil {
+		return err
+	}
+
+	c, ctx, cancel, err := dial(b)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+	defer c.Close()
+
+	res, err := c.Call(ctx, protocol.MethodSend, protocol.SendParams{
+		Address:   *address,
+		Transport: *transport,
+		Payload:   payload,
+		UUIDPort:  *port,
+	})
+	if err != nil {
+		return err
+	}
+	var r protocol.SendResult
+	if err := client.Decode(res, &r); err != nil {
+		return err
+	}
+	fmt.Printf("sent %d bytes in %d µs\n", r.BytesSent, r.LatencyMicros)
+	return nil
+}
+
+func readPayload(file, inline string) ([]byte, error) {
+	if file != "" && inline != "" {
+		return nil, errors.New("--file and --data are mutually exclusive")
+	}
+	if inline != "" {
+		return []byte(inline), nil
+	}
+	if file == "-" {
+		return io.ReadAll(os.Stdin)
+	}
+	if file != "" {
+		return os.ReadFile(file)
+	}
+	return nil, errors.New("provide --file or --data")
+}
+
+func init() { register(sendCmd{}) }

--- a/cli/ubtctl/commands/status.go
+++ b/cli/ubtctl/commands/status.go
@@ -1,0 +1,46 @@
+package commands
+
+import (
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/sraodev/bluetooth-service-rfcomm-python/cli/ubtctl/client"
+	"github.com/sraodev/bluetooth-service-rfcomm-python/sdk/go/pkg/protocol"
+)
+
+type statusCmd struct{}
+
+func (statusCmd) Name() string     { return "status" }
+func (statusCmd) Synopsis() string { return "show daemon health and registered drivers" }
+
+func (statusCmd) Run(args []string, _ RootInfo) error {
+	fs := flag.NewFlagSet("status", flag.ContinueOnError)
+	var b baseFlags
+	bindBase(fs, &b)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	c, ctx, cancel, err := dial(b)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+	defer c.Close()
+
+	res, err := c.Call(ctx, protocol.MethodStatus, nil)
+	if err != nil {
+		return err
+	}
+	var s protocol.StatusResult
+	if err := client.Decode(res, &s); err != nil {
+		return err
+	}
+	fmt.Printf("state:    %s\n", s.State)
+	fmt.Printf("sessions: %d\n", s.ActiveSessions)
+	fmt.Printf("drivers:  %s\n", strings.Join(s.Drivers, ", "))
+	return nil
+}
+
+func init() { register(statusCmd{}) }

--- a/cli/ubtctl/commands/version.go
+++ b/cli/ubtctl/commands/version.go
@@ -1,0 +1,51 @@
+package commands
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/sraodev/bluetooth-service-rfcomm-python/cli/ubtctl/client"
+	"github.com/sraodev/bluetooth-service-rfcomm-python/sdk/go/pkg/protocol"
+)
+
+type versionCmd struct{}
+
+func (versionCmd) Name() string     { return "version" }
+func (versionCmd) Synopsis() string { return "print CLI + daemon + protocol versions" }
+
+func (versionCmd) Run(args []string, info RootInfo) error {
+	fs := flag.NewFlagSet("version", flag.ContinueOnError)
+	var b baseFlags
+	bindBase(fs, &b)
+	clientOnly := fs.Bool("client-only", false, "skip the daemon round-trip")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	fmt.Printf("ubtctl   %s (commit %s)\n", info.CLIVersion, info.Commit)
+	fmt.Printf("protocol %s (wire v1)\n", protocol.Version)
+	if *clientOnly {
+		return nil
+	}
+
+	c, ctx, cancel, err := dial(b)
+	if err != nil {
+		fmt.Printf("ubtd     not reachable: %v\n", err)
+		return nil
+	}
+	defer cancel()
+	defer c.Close()
+
+	res, err := c.Call(ctx, protocol.MethodVersion, nil)
+	if err != nil {
+		return err
+	}
+	var v protocol.VersionResult
+	if err := client.Decode(res, &v); err != nil {
+		return err
+	}
+	fmt.Printf("ubtd     %s (commit %s, protocol %s)\n", v.DaemonVersion, v.Commit, v.ProtocolVersion)
+	return nil
+}
+
+func init() { register(versionCmd{}) }

--- a/cli/ubtctl/main.go
+++ b/cli/ubtctl/main.go
@@ -1,0 +1,40 @@
+// Command ubtctl is the Universal Bluetooth control CLI.
+//
+// It is a thin presentation layer: every command compiles to one or more
+// requests against ubtd over the wire format documented in
+// common/protocol/framing.md. The same command surface is what the AI
+// planner targets, so adding a verb here automatically extends the AI
+// tool registry.
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/sraodev/bluetooth-service-rfcomm-python/cli/ubtctl/commands"
+)
+
+// Set at link time alongside ubtd.
+var (
+	cliVersion = "0.1.0-dev"
+	commit     = "unknown"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		commands.PrintRootUsage(cliVersion)
+		os.Exit(2)
+	}
+
+	name, args := os.Args[1], os.Args[2:]
+	cmd, ok := commands.Lookup(name)
+	if !ok {
+		fmt.Fprintf(os.Stderr, "ubtctl: unknown command %q\n\n", name)
+		commands.PrintRootUsage(cliVersion)
+		os.Exit(2)
+	}
+	if err := cmd.Run(args, commands.RootInfo{CLIVersion: cliVersion, Commit: commit}); err != nil {
+		fmt.Fprintf(os.Stderr, "ubtctl %s: %v\n", name, err)
+		os.Exit(1)
+	}
+}

--- a/cli/ubtd/main.go
+++ b/cli/ubtd/main.go
@@ -1,0 +1,89 @@
+// Command ubtd is the Universal Bluetooth control-plane daemon.
+//
+// It listens on a Unix domain socket, multiplexes typed requests onto
+// platform-specific transport drivers, and is the only process that
+// touches the Bluetooth stack directly. Both the typed CLI (ubtctl) and
+// the AI planner speak to it through the wire format documented in
+// common/protocol/framing.md.
+package main
+
+import (
+	"context"
+	"flag"
+	"log/slog"
+	"net"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+
+	"github.com/sraodev/bluetooth-service-rfcomm-python/cli/ubtd/server"
+	"github.com/sraodev/bluetooth-service-rfcomm-python/sdk/go/pkg/sockaddr"
+	"github.com/sraodev/bluetooth-service-rfcomm-python/sdk/go/pkg/transport"
+	"github.com/sraodev/bluetooth-service-rfcomm-python/sdk/go/pkg/transport/stub"
+)
+
+// Set at link time: -ldflags "-X main.daemonVersion=... -X main.commit=..."
+var (
+	daemonVersion = "0.1.0-dev"
+	commit        = "unknown"
+)
+
+func main() {
+	socket := flag.String("socket", sockaddr.Default(), "Unix domain socket path")
+	useStub := flag.Bool("stub", true, "register the in-memory stub driver (default true while real drivers are not yet wired up)")
+	logJSON := flag.Bool("log-json", false, "emit JSON-structured logs")
+	flag.Parse()
+
+	log := newLogger(*logJSON)
+
+	registry := transport.NewRegistry()
+	if *useStub {
+		registry.Register(stub.New())
+	}
+	defer registry.Close()
+
+	if err := os.MkdirAll(filepath.Dir(*socket), 0o755); err != nil {
+		log.Error("create socket dir", "err", err)
+		os.Exit(1)
+	}
+	// Remove stale socket from a previous crash.
+	_ = os.Remove(*socket)
+
+	ln, err := net.Listen("unix", *socket)
+	if err != nil {
+		log.Error("listen", "socket", *socket, "err", err)
+		os.Exit(1)
+	}
+	if err := os.Chmod(*socket, 0o600); err != nil {
+		log.Warn("chmod socket", "err", err)
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	log.Info("ubtd listening",
+		"socket", *socket,
+		"version", daemonVersion,
+		"drivers", registry.Names(),
+	)
+
+	srv := server.New(log, registry, daemonVersion, commit)
+	if err := srv.Serve(ctx, ln); err != nil {
+		log.Error("serve", "err", err)
+		os.Exit(1)
+	}
+	log.Info("ubtd shutdown")
+}
+
+func newLogger(asJSON bool) *slog.Logger {
+	level := slog.LevelInfo
+	if v := os.Getenv("UBTD_LOG_LEVEL"); v != "" {
+		_ = level.UnmarshalText([]byte(v))
+	}
+	opts := &slog.HandlerOptions{Level: level}
+	if asJSON {
+		return slog.New(slog.NewJSONHandler(os.Stderr, opts))
+	}
+	return slog.New(slog.NewTextHandler(os.Stderr, opts))
+}

--- a/cli/ubtd/server/dispatcher.go
+++ b/cli/ubtd/server/dispatcher.go
@@ -1,0 +1,228 @@
+// Package server hosts the UDS request dispatcher used by ubtd.
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/sraodev/bluetooth-service-rfcomm-python/sdk/go/pkg/protocol"
+	"github.com/sraodev/bluetooth-service-rfcomm-python/sdk/go/pkg/transport"
+)
+
+type Server struct {
+	log      *slog.Logger
+	registry *transport.Registry
+	commit   string
+	version  string
+
+	sessions atomic.Int64
+}
+
+func New(log *slog.Logger, registry *transport.Registry, daemonVersion, commit string) *Server {
+	return &Server{
+		log:      log,
+		registry: registry,
+		commit:   commit,
+		version:  daemonVersion,
+	}
+}
+
+// Serve accepts connections from ln until ctx is cancelled.
+func (s *Server) Serve(ctx context.Context, ln net.Listener) error {
+	go func() {
+		<-ctx.Done()
+		_ = ln.Close()
+	}()
+
+	var wg sync.WaitGroup
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			if ctx.Err() != nil {
+				wg.Wait()
+				return nil
+			}
+			return err
+		}
+		wg.Add(1)
+		go func(c net.Conn) {
+			defer wg.Done()
+			defer c.Close()
+			s.handleConn(ctx, c)
+		}(conn)
+	}
+}
+
+func (s *Server) handleConn(ctx context.Context, c net.Conn) {
+	s.sessions.Add(1)
+	defer s.sessions.Add(-1)
+
+	for {
+		req, err := protocol.ReadFrame(c)
+		if err != nil {
+			return
+		}
+		if req.Kind != protocol.KindRequest {
+			s.writeError(c, req.ID, protocol.CodeInvalidParams, "expected kind=request")
+			continue
+		}
+		s.dispatch(ctx, c, req)
+	}
+}
+
+func (s *Server) dispatch(ctx context.Context, c net.Conn, req *protocol.Envelope) {
+	switch req.Method {
+	case protocol.MethodPing:
+		s.writeResult(c, req.ID, protocol.PingResult{
+			Pong:             "pong",
+			ServerTimeUnixMs: time.Now().UnixMilli(),
+		})
+	case protocol.MethodVersion:
+		s.writeResult(c, req.ID, protocol.VersionResult{
+			DaemonVersion:   s.version,
+			ProtocolVersion: protocol.Version,
+			Commit:          s.commit,
+		})
+	case protocol.MethodCapabilities:
+		s.writeResult(c, req.ID, protocol.CapabilitiesResult{Capabilities: s.registry.Capabilities()})
+	case protocol.MethodStatus:
+		s.writeResult(c, req.ID, protocol.StatusResult{
+			State:          "ready",
+			ActiveSessions: int(s.sessions.Load()),
+			Drivers:        s.registry.Names(),
+		})
+	case protocol.MethodDiscover:
+		s.handleDiscover(ctx, c, req)
+	case protocol.MethodSend:
+		s.handleSend(ctx, c, req)
+	default:
+		s.writeError(c, req.ID, protocol.CodeUnknownMethod, fmt.Sprintf("method %q", req.Method))
+	}
+}
+
+func (s *Server) handleDiscover(ctx context.Context, c net.Conn, req *protocol.Envelope) {
+	var p protocol.DiscoverParams
+	if err := decodeParams(req.Params, &p); err != nil {
+		s.writeError(c, req.ID, protocol.CodeInvalidParams, err.Error())
+		return
+	}
+	if p.Transport == "" {
+		// Default to the first driver we have.
+		caps := s.registry.Capabilities()
+		if len(caps) == 0 {
+			s.writeError(c, req.ID, protocol.CodeNotImplemented, "no drivers registered")
+			return
+		}
+		p.Transport = caps[0].Transport
+	}
+	driver, ok := s.registry.ForTransport(p.Transport)
+	if !ok {
+		s.writeError(c, req.ID, protocol.CodeNotImplemented, "no driver for transport "+p.Transport)
+		return
+	}
+	if p.TimeoutSeconds <= 0 {
+		p.TimeoutSeconds = 8
+	}
+	scanCtx, cancel := context.WithTimeout(ctx, time.Duration(p.TimeoutSeconds)*time.Second)
+	defer cancel()
+
+	out := make(chan protocol.Device, 8)
+	errCh := make(chan error, 1)
+	go func() { errCh <- driver.Discover(scanCtx, p, out); close(out) }()
+
+	for dev := range out {
+		s.writeEvent(c, req.ID, protocol.MethodDiscover, dev)
+	}
+	if err := <-errCh; err != nil && err != context.DeadlineExceeded && err != context.Canceled {
+		s.writeError(c, req.ID, protocol.CodeTransportError, err.Error())
+		return
+	}
+	s.writeResult(c, req.ID, map[string]any{})
+}
+
+func (s *Server) handleSend(ctx context.Context, c net.Conn, req *protocol.Envelope) {
+	var p protocol.SendParams
+	if err := decodeParams(req.Params, &p); err != nil {
+		s.writeError(c, req.ID, protocol.CodeInvalidParams, err.Error())
+		return
+	}
+	if p.Transport == "" {
+		s.writeError(c, req.ID, protocol.CodeInvalidParams, "transport required")
+		return
+	}
+	driver, ok := s.registry.ForTransport(p.Transport)
+	if !ok {
+		s.writeError(c, req.ID, protocol.CodeNotImplemented, "no driver for transport "+p.Transport)
+		return
+	}
+	res, err := driver.Send(ctx, p)
+	if err != nil {
+		s.writeError(c, req.ID, protocol.CodeTransportError, err.Error())
+		return
+	}
+	s.writeResult(c, req.ID, res)
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func decodeParams(raw map[string]any, dst any) error {
+	if raw == nil {
+		return nil
+	}
+	b, err := json.Marshal(raw)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(b, dst)
+}
+
+func toMap(v any) map[string]any {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return map[string]any{"_marshal_error": err.Error()}
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		return map[string]any{"_unmarshal_error": err.Error()}
+	}
+	return m
+}
+
+func (s *Server) writeResult(c net.Conn, id string, result any) {
+	if err := protocol.WriteFrame(c, &protocol.Envelope{
+		ID:     id,
+		Kind:   protocol.KindResponse,
+		Result: toMap(result),
+	}); err != nil {
+		s.log.Warn("write result", "err", err)
+	}
+}
+
+func (s *Server) writeEvent(c net.Conn, id, method string, payload any) {
+	if err := protocol.WriteFrame(c, &protocol.Envelope{
+		ID:     id,
+		Kind:   protocol.KindEvent,
+		Method: method,
+		Params: toMap(payload),
+	}); err != nil {
+		s.log.Warn("write event", "err", err)
+	}
+}
+
+func (s *Server) writeError(c net.Conn, id, code, message string) {
+	if err := protocol.WriteFrame(c, &protocol.Envelope{
+		ID:    id,
+		Kind:  protocol.KindResponse,
+		Error: &protocol.Error{Code: code, Message: message},
+	}); err != nil {
+		s.log.Warn("write error", "err", err)
+	}
+}

--- a/common/protocol/framing.md
+++ b/common/protocol/framing.md
@@ -1,0 +1,65 @@
+# Wire framing — v1
+
+The control-plane connection between `ubtctl` and `ubtd` is a length-prefixed
+stream of JSON envelopes over a Unix domain socket (or TCP, for remote
+deployments). The schema mirrors `v1.proto`; switching to gRPC is a transport
+swap, not a redesign.
+
+## Frame
+
+```
++---------------------+----------------------------+
+| 4 bytes, big-endian | JSON body (UTF-8, no BOM)  |
+| body length (uint32)|                            |
++---------------------+----------------------------+
+```
+
+Maximum body size is 16 MiB; the daemon rejects larger frames with `frame_too_large`.
+
+## Envelope
+
+```jsonc
+{
+  "id": "uuid-v4",          // correlation id, echoed in responses/events
+  "kind": "request" |
+          "response" |
+          "event",
+  "method": "Discover",     // request/event only
+  "params": { ... },        // request/event only
+  "result": { ... },        // response only, on success
+  "error":  {               // response only, on failure
+    "code": "not_implemented",
+    "message": "...",
+    "details": { ... }
+  }
+}
+```
+
+Streaming responses (e.g., `Discover`) are delivered as a sequence of `event`
+frames sharing the originating request's `id`, terminated by a final
+`response` frame (empty `result`) or an `error`.
+
+## Methods (v1)
+
+| Method         | Streaming | Purpose                              |
+|----------------|-----------|--------------------------------------|
+| `Ping`         | no        | Liveness + clock skew check          |
+| `Version`      | no        | Daemon + protocol version            |
+| `Capabilities` | no        | Per-transport feature matrix         |
+| `Discover`     | server    | Emit `Device` events until timeout   |
+| `Send`         | no        | One-shot payload to a peer           |
+| `Status`       | no        | Daemon health + active sessions      |
+
+## Error codes
+
+Stable, machine-readable. Add new codes; never repurpose existing ones.
+
+| Code                | Meaning                                       |
+|---------------------|-----------------------------------------------|
+| `not_implemented`   | Method known to schema, no driver supports it |
+| `unknown_method`    | Method not in schema                          |
+| `invalid_params`    | Schema mismatch / required field missing      |
+| `transport_error`   | Underlying driver failure (BlueZ, WinRT, ...) |
+| `not_found`         | Address/session not known                     |
+| `frame_too_large`   | Payload exceeded 16 MiB cap                   |
+| `internal`          | Unexpected daemon error                       |

--- a/common/protocol/v1.proto
+++ b/common/protocol/v1.proto
@@ -1,0 +1,87 @@
+// Universal Bluetooth control-plane protocol, version 1.
+//
+// Status: source of truth for *future* gRPC stubs. The current Go daemon
+// (`ubtd`) speaks the wire format described in `framing.md`, which is a
+// length-prefixed JSON envelope semantically equivalent to the messages
+// declared here. Migrating to gRPC is a transport swap, not a redesign.
+//
+// All names below match the JSON field names used on the wire today.
+
+syntax = "proto3";
+
+package universalbt.v1;
+
+// ---------------------------------------------------------------------------
+// Common types
+// ---------------------------------------------------------------------------
+
+message Device {
+  string address    = 1; // MAC or BLE identifier
+  string name       = 2;
+  string transport  = 3; // "rfcomm" | "ble" | ...
+  int32  rssi       = 4;
+  map<string, string> attributes = 5;
+}
+
+message Capability {
+  string transport = 1;
+  bool   discover  = 2;
+  bool   pair      = 3;
+  bool   stream    = 4;
+  int32  max_mtu   = 5;
+}
+
+message Error {
+  string code    = 1; // stable machine-readable code
+  string message = 2;
+  map<string, string> details = 3;
+}
+
+// ---------------------------------------------------------------------------
+// RPC surface
+// ---------------------------------------------------------------------------
+
+service Control {
+  rpc Ping        (PingRequest)        returns (PingResponse);
+  rpc Version     (VersionRequest)     returns (VersionResponse);
+  rpc Capabilities(CapabilitiesRequest) returns (CapabilitiesResponse);
+  rpc Discover    (DiscoverRequest)    returns (stream Device);
+  rpc Send        (SendRequest)        returns (SendResponse);
+  rpc Status      (StatusRequest)      returns (StatusResponse);
+}
+
+message PingRequest  {}
+message PingResponse { string pong = 1; int64 server_time_unix_ms = 2; }
+
+message VersionRequest  {}
+message VersionResponse {
+  string daemon_version   = 1;
+  string protocol_version = 2;
+  string commit           = 3;
+}
+
+message CapabilitiesRequest  {}
+message CapabilitiesResponse { repeated Capability capabilities = 1; }
+
+message DiscoverRequest {
+  string transport       = 1; // empty = all available
+  int32  timeout_seconds = 2;
+}
+
+message SendRequest {
+  string address   = 1;
+  string transport = 2;
+  bytes  payload   = 3;
+  int32  uuid_port = 4; // RFCOMM channel / GATT handle
+}
+message SendResponse {
+  int64 bytes_sent     = 1;
+  int64 latency_micros = 2;
+}
+
+message StatusRequest  {}
+message StatusResponse {
+  string state            = 1; // "ready" | "degraded" | "starting"
+  int32  active_sessions  = 2;
+  repeated string drivers = 3;
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/sraodev/bluetooth-service-rfcomm-python
+
+go 1.24.7

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -1,12 +1,37 @@
-# Go SDK (placeholder)
+# Go SDK
 
-This directory is reserved for a future Go implementation of the Universal
-Bluetooth SDK. Contributions welcome! Suggested next steps:
+Shared Go packages used by `ubtd` (the daemon) and `ubtctl` (the CLI).
 
-1. Outline the public package API (`btserver`, `btclient`, etc.).
-2. Define how it will interoperate with the shared protocol specs in
-   `common/protocol/`.
-3. Reuse the message schema in `common/message-schema/` for serialization.
+```
+sdk/go/pkg/
+├── protocol/    # wire envelope + length-prefixed JSON codec (see common/protocol/framing.md)
+├── sockaddr/    # default Unix socket location, single source of truth
+└── transport/   # Driver interface + Registry + reference stub driver
+```
 
-Feel free to open an issue or PR if you'd like to help bootstrap the Go SDK.
+## Driver contract
 
+Every transport adapter (RFCOMM-BlueZ, BLE-CoreBluetooth, WinRT, …) implements
+`transport.Driver`:
+
+```go
+type Driver interface {
+    Name() string
+    Capability() protocol.Capability
+    Discover(ctx, params, out chan<- Device) error
+    Send(ctx, params) (SendResult, error)
+    Close() error
+}
+```
+
+`stub.New()` is the in-memory reference driver — used for tests, CI, and any
+host without Bluetooth hardware. Real drivers land alongside it in
+`pkg/transport/<name>/`.
+
+## Status
+
+- Protocol + codec: implemented, wire v1.
+- Stub driver: implemented.
+- BlueZ (Linux) / CoreBluetooth (macOS) / WinRT (Windows) drivers: TODO.
+- gRPC transport: TODO (the JSON-over-UDS framing is the v1 wire; gRPC will be
+  v2, generated from `common/protocol/v1.proto`).

--- a/sdk/go/pkg/protocol/codec.go
+++ b/sdk/go/pkg/protocol/codec.go
@@ -1,0 +1,53 @@
+package protocol
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+)
+
+const maxFrameBytes = MaxFrameKB * 1024
+
+// WriteFrame serialises env as a length-prefixed JSON frame.
+func WriteFrame(w io.Writer, env *Envelope) error {
+	body, err := json.Marshal(env)
+	if err != nil {
+		return fmt.Errorf("marshal envelope: %w", err)
+	}
+	if len(body) > maxFrameBytes {
+		return &Error{Code: CodeFrameTooLarge, Message: fmt.Sprintf("frame %d > %d bytes", len(body), maxFrameBytes)}
+	}
+	var hdr [4]byte
+	binary.BigEndian.PutUint32(hdr[:], uint32(len(body)))
+	if _, err := w.Write(hdr[:]); err != nil {
+		return err
+	}
+	_, err = w.Write(body)
+	return err
+}
+
+// ReadFrame reads one length-prefixed JSON frame.
+func ReadFrame(r io.Reader) (*Envelope, error) {
+	var hdr [4]byte
+	if _, err := io.ReadFull(r, hdr[:]); err != nil {
+		return nil, err
+	}
+	n := binary.BigEndian.Uint32(hdr[:])
+	if n == 0 {
+		return nil, errors.New("empty frame")
+	}
+	if n > maxFrameBytes {
+		return nil, &Error{Code: CodeFrameTooLarge, Message: fmt.Sprintf("frame %d > %d bytes", n, maxFrameBytes)}
+	}
+	body := make([]byte, n)
+	if _, err := io.ReadFull(r, body); err != nil {
+		return nil, err
+	}
+	var env Envelope
+	if err := json.Unmarshal(body, &env); err != nil {
+		return nil, fmt.Errorf("unmarshal envelope: %w", err)
+	}
+	return &env, nil
+}

--- a/sdk/go/pkg/protocol/codec_test.go
+++ b/sdk/go/pkg/protocol/codec_test.go
@@ -1,0 +1,48 @@
+package protocol
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestFrameRoundTrip(t *testing.T) {
+	in := &Envelope{
+		ID:     "abc",
+		Kind:   KindRequest,
+		Method: MethodDiscover,
+		Params: map[string]any{"transport": "rfcomm", "timeout_seconds": float64(5)},
+	}
+	var buf bytes.Buffer
+	if err := WriteFrame(&buf, in); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	out, err := ReadFrame(&buf)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if out.ID != in.ID || out.Kind != in.Kind || out.Method != in.Method {
+		t.Fatalf("envelope mismatch: %+v vs %+v", out, in)
+	}
+	if got, want := out.Params["transport"], "rfcomm"; got != want {
+		t.Fatalf("params: got %v want %v", got, want)
+	}
+}
+
+func TestErrorEnvelope(t *testing.T) {
+	in := &Envelope{
+		ID:    "x",
+		Kind:  KindResponse,
+		Error: &Error{Code: CodeUnknownMethod, Message: "no such method"},
+	}
+	var buf bytes.Buffer
+	if err := WriteFrame(&buf, in); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	out, err := ReadFrame(&buf)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if out.Error == nil || out.Error.Code != CodeUnknownMethod {
+		t.Fatalf("error not preserved: %+v", out.Error)
+	}
+}

--- a/sdk/go/pkg/protocol/messages.go
+++ b/sdk/go/pkg/protocol/messages.go
@@ -1,0 +1,107 @@
+// Package protocol defines the wire types shared by ubtd and ubtctl.
+//
+// The schema is mirrored in common/protocol/v1.proto. Keep them in sync.
+package protocol
+
+const (
+	Version    = "1.0.0"
+	MaxFrameKB = 16 * 1024
+)
+
+type Kind string
+
+const (
+	KindRequest  Kind = "request"
+	KindResponse Kind = "response"
+	KindEvent    Kind = "event"
+)
+
+const (
+	MethodPing         = "Ping"
+	MethodVersion      = "Version"
+	MethodCapabilities = "Capabilities"
+	MethodDiscover     = "Discover"
+	MethodSend         = "Send"
+	MethodStatus       = "Status"
+)
+
+const (
+	CodeUnknownMethod   = "unknown_method"
+	CodeNotImplemented  = "not_implemented"
+	CodeInvalidParams   = "invalid_params"
+	CodeTransportError  = "transport_error"
+	CodeNotFound        = "not_found"
+	CodeFrameTooLarge   = "frame_too_large"
+	CodeInternal        = "internal"
+)
+
+type Envelope struct {
+	ID     string         `json:"id"`
+	Kind   Kind           `json:"kind"`
+	Method string         `json:"method,omitempty"`
+	Params map[string]any `json:"params,omitempty"`
+	Result map[string]any `json:"result,omitempty"`
+	Error  *Error         `json:"error,omitempty"`
+}
+
+type Error struct {
+	Code    string            `json:"code"`
+	Message string            `json:"message"`
+	Details map[string]string `json:"details,omitempty"`
+}
+
+func (e *Error) Error() string { return e.Code + ": " + e.Message }
+
+type Device struct {
+	Address    string            `json:"address"`
+	Name       string            `json:"name"`
+	Transport  string            `json:"transport"`
+	RSSI       int               `json:"rssi"`
+	Attributes map[string]string `json:"attributes,omitempty"`
+}
+
+type Capability struct {
+	Transport string `json:"transport"`
+	Discover  bool   `json:"discover"`
+	Pair      bool   `json:"pair"`
+	Stream    bool   `json:"stream"`
+	MaxMTU    int    `json:"max_mtu"`
+}
+
+type PingResult struct {
+	Pong             string `json:"pong"`
+	ServerTimeUnixMs int64  `json:"server_time_unix_ms"`
+}
+
+type VersionResult struct {
+	DaemonVersion   string `json:"daemon_version"`
+	ProtocolVersion string `json:"protocol_version"`
+	Commit          string `json:"commit"`
+}
+
+type CapabilitiesResult struct {
+	Capabilities []Capability `json:"capabilities"`
+}
+
+type DiscoverParams struct {
+	Transport      string `json:"transport,omitempty"`
+	TimeoutSeconds int    `json:"timeout_seconds,omitempty"`
+}
+
+type SendParams struct {
+	Address   string `json:"address"`
+	Transport string `json:"transport"`
+	Payload   []byte `json:"payload"`
+	UUIDPort  int    `json:"uuid_port,omitempty"`
+}
+
+type SendResult struct {
+	BytesSent     int64 `json:"bytes_sent"`
+	LatencyMicros int64 `json:"latency_micros"`
+}
+
+type StatusResult struct {
+	State          string   `json:"state"`
+	ActiveSessions int      `json:"active_sessions"`
+	Drivers        []string `json:"drivers"`
+}

--- a/sdk/go/pkg/sockaddr/sockaddr.go
+++ b/sdk/go/pkg/sockaddr/sockaddr.go
@@ -1,0 +1,24 @@
+// Package sockaddr resolves the default Unix socket path for the daemon.
+//
+// Centralised so ubtd and ubtctl can never disagree.
+package sockaddr
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// Default returns the path ubtd listens on (and ubtctl dials) by default.
+//
+//   - Honour UBTD_SOCKET if set.
+//   - Otherwise prefer $XDG_RUNTIME_DIR/ubtd.sock (per-user, tmpfs).
+//   - Fall back to /tmp/ubtd.sock for portability.
+func Default() string {
+	if s := os.Getenv("UBTD_SOCKET"); s != "" {
+		return s
+	}
+	if r := os.Getenv("XDG_RUNTIME_DIR"); r != "" {
+		return filepath.Join(r, "ubtd.sock")
+	}
+	return "/tmp/ubtd.sock"
+}

--- a/sdk/go/pkg/transport/driver.go
+++ b/sdk/go/pkg/transport/driver.go
@@ -1,0 +1,81 @@
+// Package transport defines the port through which ubtd talks to concrete
+// Bluetooth (or Bluetooth-like) hardware adapters.
+//
+// Each platform/transport pair (Linux+RFCOMM, macOS+CoreBluetooth, ...)
+// implements Driver. The daemon picks drivers at runtime based on what
+// the host advertises through Capabilities().
+package transport
+
+import (
+	"context"
+
+	"github.com/sraodev/bluetooth-service-rfcomm-python/sdk/go/pkg/protocol"
+)
+
+// Driver is the contract every transport adapter must satisfy.
+type Driver interface {
+	// Name is a short identifier ("rfcomm-bluez", "ble-corebluetooth").
+	Name() string
+
+	// Capability advertises what this driver can do on this host.
+	Capability() protocol.Capability
+
+	// Discover emits devices over out until ctx is cancelled. Drivers that
+	// cannot scan return CodeNotImplemented immediately.
+	Discover(ctx context.Context, params protocol.DiscoverParams, out chan<- protocol.Device) error
+
+	// Send delivers a payload to a peer. Returns bytes-written + latency.
+	Send(ctx context.Context, params protocol.SendParams) (protocol.SendResult, error)
+
+	// Close releases any background resources held by the driver.
+	Close() error
+}
+
+// Registry holds drivers selected for the running daemon.
+type Registry struct {
+	byName      map[string]Driver
+	byTransport map[string]Driver
+}
+
+func NewRegistry() *Registry {
+	return &Registry{
+		byName:      map[string]Driver{},
+		byTransport: map[string]Driver{},
+	}
+}
+
+func (r *Registry) Register(d Driver) {
+	r.byName[d.Name()] = d
+	r.byTransport[d.Capability().Transport] = d
+}
+
+func (r *Registry) ForTransport(t string) (Driver, bool) {
+	d, ok := r.byTransport[t]
+	return d, ok
+}
+
+func (r *Registry) Names() []string {
+	out := make([]string, 0, len(r.byName))
+	for n := range r.byName {
+		out = append(out, n)
+	}
+	return out
+}
+
+func (r *Registry) Capabilities() []protocol.Capability {
+	out := make([]protocol.Capability, 0, len(r.byName))
+	for _, d := range r.byName {
+		out = append(out, d.Capability())
+	}
+	return out
+}
+
+func (r *Registry) Close() error {
+	var firstErr error
+	for _, d := range r.byName {
+		if err := d.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}

--- a/sdk/go/pkg/transport/stub/stub.go
+++ b/sdk/go/pkg/transport/stub/stub.go
@@ -1,0 +1,66 @@
+// Package stub provides an in-memory transport driver used for tests and
+// for running the daemon on hosts without Bluetooth hardware (CI, dev
+// containers, the AI planner's dry-run mode).
+package stub
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/sraodev/bluetooth-service-rfcomm-python/sdk/go/pkg/protocol"
+)
+
+type Driver struct {
+	devices []protocol.Device
+}
+
+func New() *Driver {
+	return &Driver{
+		devices: []protocol.Device{
+			{Address: "AA:BB:CC:DD:EE:01", Name: "stub-pi", Transport: "rfcomm", RSSI: -42},
+			{Address: "AA:BB:CC:DD:EE:02", Name: "stub-esp32", Transport: "rfcomm", RSSI: -67},
+		},
+	}
+}
+
+func (d *Driver) Name() string { return "stub" }
+
+func (d *Driver) Capability() protocol.Capability {
+	return protocol.Capability{
+		Transport: "rfcomm",
+		Discover:  true,
+		Pair:      false,
+		Stream:    true,
+		MaxMTU:    1024,
+	}
+}
+
+func (d *Driver) Discover(ctx context.Context, _ protocol.DiscoverParams, out chan<- protocol.Device) error {
+	for _, dev := range d.devices {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case out <- dev:
+		}
+		// Simulate scan latency without making tests slow.
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+	return nil
+}
+
+func (d *Driver) Send(_ context.Context, params protocol.SendParams) (protocol.SendResult, error) {
+	if params.Address == "" {
+		return protocol.SendResult{}, errors.New("address required")
+	}
+	return protocol.SendResult{
+		BytesSent:     int64(len(params.Payload)),
+		LatencyMicros: 1234,
+	}, nil
+}
+
+func (d *Driver) Close() error { return nil }


### PR DESCRIPTION
Lays the architectural foundation chosen in the planning thread:
hexagonal control plane where ubtctl never touches the radio and every
command flows through ubtd over a versioned wire format. The same
surface is what the AI planner will target, so adding a verb here
extends the AI tool registry mechanically.

- common/protocol: v1.proto IDL (future gRPC) + framing.md describing
  the length-prefixed JSON envelope used by the v1 wire today.
- sdk/go/pkg/protocol: shared envelope types and codec.
- sdk/go/pkg/transport: Driver port + Registry; in-memory stub driver
  so the daemon runs on hosts without Bluetooth hardware.
- sdk/go/pkg/sockaddr: single source of truth for socket location.
- cli/ubtd: UDS server with ping/version/capabilities/status/discover/
  send dispatch, structured slog logging, signal-driven shutdown.
- cli/ubtctl: typed subcommand registry with ping, version, status,
  capabilities, discover (streaming), send.
- Codec round-trip tests; end-to-end smoke verified against the stub.